### PR TITLE
I've added regression tests for `WordIndex`.

### DIFF
--- a/mcp_server/Cargo.lock
+++ b/mcp_server/Cargo.lock
@@ -184,6 +184,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +292,18 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if 1.0.1",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -443,6 +471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +500,7 @@ dependencies = [
  "jsonrpc-http-server",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -491,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -606,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +686,19 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ryu"
@@ -739,6 +793,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -860,6 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,3 +1038,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]

--- a/mcp_server/Cargo.toml
+++ b/mcp_server/Cargo.toml
@@ -11,3 +11,6 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 jsonrpc-http-server = "18.0.0"
 clap = { version = "4.4.8", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/mcp_server/src/main.rs
+++ b/mcp_server/src/main.rs
@@ -9,13 +9,13 @@ use jsonrpc_http_server::jsonrpc_core::{Error, ErrorCode, IoHandler, Params, Val
 use jsonrpc_http_server::{DomainsValidation, ServerBuilder};
 
 #[derive(Debug)]
-struct WordIndex {
-    lines: Vec<String>,
-    index: HashMap<String, Vec<usize>>,
+pub struct WordIndex {
+    pub lines: Vec<String>,
+    pub index: HashMap<String, Vec<usize>>,
 }
 
 impl WordIndex {
-    fn new(filename: &str) -> Result<Self, std::io::Error> {
+    pub fn new(filename: &str) -> Result<Self, std::io::Error> {
         let path = Path::new(filename);
         let file = File::open(path)?;
         let reader = BufReader::new(file);
@@ -208,4 +208,187 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // }
 
     Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // use std::fs; // Removed unused import
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    // Helper function to create a WordIndex from test_db.txt
+    fn word_index_from_test_db() -> WordIndex {
+        // To ensure tests can run regardless of where `cargo test` is invoked,
+        // we need to locate test_db.txt relative to the Cargo.toml of this package.
+        // This assumes test_db.txt is in the root of the mcp_server package.
+        // let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()); // Removed unused variable
+        // let db_path = std::path::Path::new(&manifest_dir).join("../test_db.txt");  // Removed unused variable
+        // The previous step created test_db.txt in mcp_server/test_db.txt, but the server itself is in mcp_server.
+        // So from within mcp_server (where Cargo.toml is), test_db.txt is just "test_db.txt"
+        // However, the original instruction was "mcp_server/test_db.txt".
+        // Let's assume the `WordIndex::new` is called from the root of the mcp_server crate.
+        // The test file `test_db.txt` was created in `mcp_server/test_db.txt`.
+        // So the path for the tests should be just "test_db.txt" if tests are run from `mcp_server` directory.
+        // Or it could be `../mcp_server/test_db.txt` if tests are run from `/app`
+        // Let's try to be robust by checking CARGO_MANIFEST_DIR
+        // The file was created at "mcp_server/test_db.txt".
+        // If CARGO_MANIFEST_DIR is /app/mcp_server, then path is "test_db.txt"
+        // If running from /app, then path is "mcp_server/test_db.txt"
+        // The original code used "test_db.txt" directly. Let's stick to that for the helper.
+        // The tests will be run from the `mcp_server` crate root.
+        WordIndex::new("test_db.txt").expect("Failed to load test_db.txt for testing. Ensure it is in the mcp_server directory.")
+    }
+
+    #[test]
+    fn test_word_index_new_success() {
+        let wi = word_index_from_test_db();
+        assert!(!wi.lines.is_empty(), "Lines should not be empty after loading test_db.txt");
+        assert!(!wi.index.is_empty(), "Index should not be empty after loading test_db.txt");
+    }
+
+    #[test]
+    fn test_word_index_new_file_not_found() {
+        match WordIndex::new("non_existent_file.txt") {
+            Ok(_) => panic!("Should have failed for a non-existent file"),
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+        }
+    }
+
+    #[test]
+    fn test_word_index_new_empty_file() {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        // writeln!(temp_file, "").expect("Failed to write to temp file"); // Write an empty line to avoid EOF error on read_line
+        // The original WordIndex::new reads lines and pushes them. An empty file will result in an empty lines vector.
+        // If the file has one empty line, lines vector will have one empty string.
+
+        // Test with a file that has one empty line
+        writeln!(temp_file, "").expect("Failed to write one empty line to temp file");
+        let wi_one_empty_line = WordIndex::new(temp_file.path().to_str().unwrap())
+            .expect("Failed to load file with one empty line");
+        assert_eq!(wi_one_empty_line.lines.len(), 1, "Should have one line for a file with one empty line");
+        assert!(wi_one_empty_line.lines[0].is_empty(), "The first line should be empty");
+        assert!(wi_one_empty_line.index.is_empty(), "Index should be empty if only an empty line exists");
+
+        // Test with a truly empty file (0 bytes)
+        let temp_file_truly_empty = NamedTempFile::new().expect("Failed to create truly empty temp file");
+        // Do not write anything to make it truly empty
+        let wi_truly_empty = WordIndex::new(temp_file_truly_empty.path().to_str().unwrap())
+            .expect("Failed to load a truly empty file");
+        assert!(wi_truly_empty.lines.is_empty(), "Lines should be empty for a truly empty file");
+        assert!(wi_truly_empty.index.is_empty(), "Index should be empty for a truly empty file");
+    }
+
+    #[test]
+    fn test_search_single_word_exists() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("hello");
+        assert_eq!(results, vec![0]);
+    }
+
+    #[test]
+    fn test_search_multiple_words_same_line() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("test line");
+        assert_eq!(results, vec![1]);
+    }
+
+    #[test]
+    fn test_search_multiple_words_different_lines() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("hello test"); // "hello" is line 0, "test" is line 1
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_word_not_exists() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("nonexistentword");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_empty_query() {
+        let wi = word_index_from_test_db();
+        let results = wi.search(" "); // space only
+        assert!(results.is_empty());
+        let results_empty = wi.search(""); // truly empty
+        assert!(results_empty.is_empty());
+    }
+
+    #[test]
+    fn test_search_mixed_casing() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("UPPERCASE"); // db has "UPPERCASE"
+        assert_eq!(results, vec![3]);
+        let results_lower = wi.search("uppercase"); // query lowercase
+        assert_eq!(results_lower, vec![3]);
+         let results_in_db_lower = wi.search("LoWeRcAsE"); // db has "lowercase"
+        assert_eq!(results_in_db_lower, vec![3]);
+    }
+
+    #[test]
+    fn test_search_with_punctuation() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("world!"); // Query with punctuation
+        assert_eq!(results, vec![0]);
+        let results_comma = wi.search("comma,");
+        assert_eq!(results_comma, vec![4]);
+        let results_period = wi.search("period.");
+        assert_eq!(results_period, vec![4]);
+    }
+
+    #[test]
+    fn test_search_numbers() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("123");
+        assert_eq!(results, vec![5]);
+        let results_multi = wi.search("123 numbers");
+        assert_eq!(results_multi, vec![5]);
+    }
+
+    #[test]
+    fn test_search_line_after_empty_line() {
+        let wi = word_index_from_test_db();
+        // The file has:
+        // An empty line follows this one. (line 6)
+        //                                (line 7 - empty)
+        // A line after an empty line.    (line 8)
+        let results = wi.search("after empty line");
+        assert_eq!(results, vec![8]);
+    }
+
+    #[test]
+    fn test_search_repeated_words() {
+        let wi = word_index_from_test_db();
+        let results = wi.search("repeated");
+        assert_eq!(results, vec![9]); // "repeated repeated words."
+        let results_double = wi.search("repeated repeated");
+        assert_eq!(results_double, vec![9]);
+    }
+
+    #[test]
+    fn test_fetch_existing_line() {
+        let wi = word_index_from_test_db();
+        let line = wi.fetch(0);
+        assert_eq!(line, Some("Hello world!".to_string()));
+        let line_2 = wi.fetch(8);
+        assert_eq!(line_2, Some("A line after an empty line.".to_string()));
+    }
+
+    #[test]
+    fn test_fetch_out_of_bounds() {
+        let wi = word_index_from_test_db();
+        let line = wi.fetch(100); // test_db.txt has 10 lines (0-9)
+        assert_eq!(line, None);
+    }
+
+    #[test]
+    fn test_fetch_line_is_empty() {
+        let wi = word_index_from_test_db();
+        // test_db.txt line 7 is empty
+        let line = wi.fetch(7);
+        assert_eq!(line, Some("".to_string()));
+    }
 }

--- a/mcp_server/test_db.txt
+++ b/mcp_server/test_db.txt
@@ -1,0 +1,10 @@
+Hello world!
+This is a test line.
+Another line for testing search functionality.
+UPPERCASE and lowercase words.
+Words with punctuation: comma, period.
+123 numbers 456.
+An empty line follows this one.
+
+A line after an empty line.
+repeated repeated words.


### PR DESCRIPTION
Here's what I did:

- Created `mcp_server/test_db.txt` with diverse content for robust testing.
- Added a new test module (`mod tests`) to `mcp_server/src/main.rs`.
- Implemented 16 unit tests for `WordIndex::new()`, `WordIndex::search()`, and `WordIndex::fetch()`, covering various scenarios including edge cases, different query types, and data variations.
- Made the `WordIndex` struct and its relevant fields/methods public to allow access from the test module.
- Added `tempfile` to `[dev-dependencies]` in `mcp_server/Cargo.toml` for tests requiring temporary file manipulation.
- All tests pass successfully.