### PR TITLE
feat: Include capabilities in initialize response

### DIFF
--- a/mcp_server/Cargo.lock
+++ b/mcp_server/Cargo.lock
@@ -184,6 +184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +420,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.1",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -497,7 +533,9 @@ name = "mcp_server"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "env_logger",
  "jsonrpc-http-server",
+ "log",
  "serde",
  "serde_json",
  "tempfile",
@@ -665,6 +703,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "tokio"
 version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1009,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/mcp_server/src/main.rs
+++ b/mcp_server/src/main.rs
@@ -29,8 +29,28 @@ struct InitializeParams {
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+struct ToolCapabilities {
+    list_changed: bool,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct SearchCapabilities {
+    enabled: bool,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct FetchCapabilities {
+    enabled: bool,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 struct ServerCapabilities {
-    // Define actual server capabilities here later if needed
+    tools: ToolCapabilities,
+    search: SearchCapabilities,
+    fetch: FetchCapabilities,
 }
 
 #[derive(Serialize, Debug)]
@@ -223,7 +243,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 let result = InitializeResult {
-                    capabilities: ServerCapabilities {},
+                    capabilities: ServerCapabilities {
+                        tools: ToolCapabilities { list_changed: true },
+                        search: SearchCapabilities { enabled: true },
+                        fetch: FetchCapabilities { enabled: true },
+                    },
                 };
                 match serde_json::to_value(result) {
                     Ok(val) => Ok(val),
@@ -525,7 +549,11 @@ mod tests {
                         // );
                     }
                     let result = InitializeResult {
-                        capabilities: ServerCapabilities {},
+                        capabilities: ServerCapabilities {
+                            tools: ToolCapabilities { list_changed: true },
+                            search: SearchCapabilities { enabled: true },
+                            fetch: FetchCapabilities { enabled: true },
+                        },
                     };
                     match serde_json::to_value(result) {
                         Ok(val) => Ok(val),
@@ -572,7 +600,16 @@ mod tests {
 
         let capabilities = result.get("capabilities").expect("Result should have capabilities");
         assert!(capabilities.is_object(), "Capabilities should be an object");
-        assert_eq!(capabilities.as_object().unwrap().len(), 0, "Capabilities object should be empty");
+
+        // Check for new capabilities
+        let tools_cap = capabilities.get("tools").expect("Capabilities should have tools");
+        assert_eq!(tools_cap.get("listChanged").expect("Tools should have listChanged").as_bool().unwrap(), true);
+
+        let search_cap = capabilities.get("search").expect("Capabilities should have search");
+        assert_eq!(search_cap.get("enabled").expect("Search should have enabled").as_bool().unwrap(), true);
+
+        let fetch_cap = capabilities.get("fetch").expect("Capabilities should have fetch");
+        assert_eq!(fetch_cap.get("enabled").expect("Fetch should have enabled").as_bool().unwrap(), true);
     }
 
     #[test]
@@ -583,7 +620,11 @@ mod tests {
             match params.parse::<InitializeParams>() {
                 Ok(_parsed_params) => {
                     let result = InitializeResult {
-                        capabilities: ServerCapabilities {},
+                        capabilities: ServerCapabilities {
+                            tools: ToolCapabilities { list_changed: false },
+                            search: SearchCapabilities { enabled: true },
+                            fetch: FetchCapabilities { enabled: true },
+                        },
                     };
                     match serde_json::to_value(result) {
                         Ok(val) => Ok(val),


### PR DESCRIPTION
The initialize response now includes the `capabilities` field with the following structure:

"capabilities": {
  "tools": { "listChanged": true },
  "search": { "enabled": true },
  "fetch": { "enabled": true }
}

This addresses an issue where the ChatGPT connector setup would fail due to an empty capabilities response.

The `ServerCapabilities` struct has been updated, and the `initialize` RPC method handler now populates these values. The corresponding unit test
`test_rpc_initialize_method_success` has also been updated to assert these new capabilities.